### PR TITLE
Pass through proxy related params to the LWP::UserAgent ctor.

### DIFF
--- a/lib/Net/Hadoop/WebHDFS/LWP.pm
+++ b/lib/Net/Hadoop/WebHDFS/LWP.pm
@@ -24,7 +24,13 @@ sub new {
     delete $self->{furl};
     $self->{debug} = $debug;
 
-    $self->{ua} = LWP::UserAgent->new;
+    my %ua_opts;
+    for my $passthru_opt (qw/ env_proxy proxy no_proxy /) {
+        $ua_opts{$passthru_opt} = $options{$passthru_opt}
+            if ( exists $options{$passthru_opt} );
+    }
+
+    $self->{ua} = LWP::UserAgent->new( %ua_opts );
     $self->{ua}->agent("Net::Hadoop::WebHDFS::LWP " . $class->VERSION );
     $self->{useragent} = $self->{ua}->agent;
 


### PR DESCRIPTION
Specifically, this passes through `proxy`, `no_proxy` and `env_proxy` params. To
tell LWP to not read the environment variables at all, env_proxy => 1 suffices,
while no_proxy allows one to selectively add domains which should be accessed
without a proxy.